### PR TITLE
More code refactoring and tweaking

### DIFF
--- a/BadgeArcadeTool/Program.cs
+++ b/BadgeArcadeTool/Program.cs
@@ -23,11 +23,6 @@ namespace BadgeArcadeTool
         private static bool keep_log = false;
         private static StreamWriter log;
 
-        static void CreateDirectoryIfNull(string dir)
-        {
-            if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
-        }
-
         public static void Log(string msg, bool newline = true)
         {
             if (newline)
@@ -45,9 +40,9 @@ namespace BadgeArcadeTool
 
         static void Main(string[] args)
         {
-            CreateDirectoryIfNull("logs");
-            CreateDirectoryIfNull("data");
-            CreateDirectoryIfNull("badges");
+            Directory.CreateDirectory("logs");
+            Directory.CreateDirectory("data");
+            Directory.CreateDirectory("badges");
             var logFile = $"logs/{now.ToString("MMMM dd, yyyy - HH-mm-ss")}.log";
             log = new StreamWriter(logFile, false, Encoding.Unicode);
 
@@ -81,7 +76,7 @@ namespace BadgeArcadeTool
             {
                 var country_dir = Path.Combine("data", country);
                 var country_id = country_list[country];
-                CreateDirectoryIfNull(country_dir);
+                Directory.CreateDirectory(country_dir);
                 foreach (var archive in badge_filelist)
                 {
                     var archive_path = Path.Combine(country_dir, archive);
@@ -169,8 +164,8 @@ namespace BadgeArcadeTool
 
                     var data_dir = Path.Combine(country_dir, "files");
                     var decompressed_data_dir = Path.Combine(country_dir, "decompressed");
-                    CreateDirectoryIfNull(data_dir);
-                    CreateDirectoryIfNull(decompressed_data_dir);
+                    Directory.CreateDirectory(data_dir);
+                    Directory.CreateDirectory(decompressed_data_dir);
 
                     foreach (var entry in sarc.SFat.Entries)
                     {
@@ -179,8 +174,8 @@ namespace BadgeArcadeTool
                         var decompressed_path = Path.Combine(decompressed_data_dir, 
                             Path.ChangeExtension(sarc.GetFilePath(entry),null));
 
-                        CreateDirectoryIfNull(Path.GetDirectoryName(path));
-                        CreateDirectoryIfNull(Path.GetDirectoryName(decompressed_path));
+                        Directory.CreateDirectory(Path.GetDirectoryName(path));
+                        Directory.CreateDirectory(Path.GetDirectoryName(decompressed_path));
                         if (!File.Exists(path))
                         {
                             Log($"New {country} file: {Path.GetFileName(path)}");
@@ -195,9 +190,9 @@ namespace BadgeArcadeTool
                                 var png_dir_full = Path.Combine("png",Path.Combine(Path.Combine("full", country), prb.CategoryName));
                                 var png_dir_tiles = Path.Combine("png", Path.Combine(Path.Combine("tiles", country), prb.CategoryName));
                                 var png_dir_downsampled = Path.Combine("png", Path.Combine(Path.Combine("downsampled", country), prb.CategoryName));
-                                CreateDirectoryIfNull(png_dir_full);
-                                CreateDirectoryIfNull(png_dir_tiles);
-                                CreateDirectoryIfNull(png_dir_downsampled);
+                                Directory.CreateDirectory(png_dir_full);
+                                Directory.CreateDirectory(png_dir_tiles);
+                                Directory.CreateDirectory(png_dir_downsampled);
                                 using (var bmp = prb.GetImage())
                                 {
                                     bmp.Save(Path.GetFullPath(Path.Combine(png_dir_full, prb.ImageName + ".png")),

--- a/BadgeArcadeTool/Program.cs
+++ b/BadgeArcadeTool/Program.cs
@@ -127,28 +127,43 @@ namespace BadgeArcadeTool
                         }
                     }
 
-                    if (File.Exists(sarc_path) || !passed_selftest)
+                    SARC sarc;
+                    if (!File.Exists(sarc_path) && passed_selftest)
+                    {
+                        keep_log = true;
+                        Log("Decrypting...", false);
+                        var dec_boss = NetworkUtils.TryDecryptBOSS(File.ReadAllBytes(archive_path));
+                        if (dec_boss == null)
+                            continue;
+                        File.WriteAllBytes(sarc_path, dec_boss.Skip(0x296).ToArray());
+
+                        sarc = SARC.Analyze(sarc_path);
+                        if (!sarc.valid)
+                        {
+                            Log($"Not a valid SARC. Maybe bad decryption...?");
+                            passed_selftest = false;
+                            File.Delete(sarc_path);
+                            continue;
+                        }
+                    }
+                    else if (!File.Exists(sarc_path))
                     {
                         Log("Done");
                         continue;
                     }
-                    keep_log = true;
-                    Log("Decrypting...", false);
-                    var dec_boss = NetworkUtils.TryDecryptBOSS(File.ReadAllBytes(archive_path));
-                    if (dec_boss == null)
-                        continue;
-                    var sarcdata = dec_boss.Skip(0x296).ToArray();
-                    File.WriteAllBytes(sarc_path, sarcdata);
-
-                    var sarc = SARC.Analyze(sarc_path);
-
-                    if (!sarc.valid)
+                    else
                     {
-                        Log($"Not a valid SARC. Maybe bad decryption...?");
-                        passed_selftest = false;
-                        File.Delete(sarc_path);
-                        continue;
+                        sarc = SARC.Analyze(sarc_path);
+                        if (!sarc.valid)
+                        {
+                            Log("SARC file corrupted");
+                            File.Delete(sarc_path);
+                            continue;
+                        }
                     }
+
+                    
+
 
                     Log($"Extracting...");
 
@@ -159,68 +174,57 @@ namespace BadgeArcadeTool
 
                     foreach (var entry in sarc.SFat.Entries)
                     {
-                        var sb = new StringBuilder();
-                        var ofs = sarc.SFnt.StringOffset + (entry.FileNameOffset & 0xFFFFFF)*4;
-                        while (sarcdata[ofs] != 0)
-                        {
-                            sb.Append((char) sarcdata[ofs++]);
-                        }
-                        var path = Path.Combine(data_dir, sb.ToString().Replace('/', Path.DirectorySeparatorChar));
-                        var decompressed_path = Path.Combine(decompressed_data_dir,
-                            sb.ToString().Replace('/', Path.DirectorySeparatorChar));
-                        var len = entry.FileDataEnd - entry.FileDataStart;
-                        var data = new byte[len];
-                        Array.Copy(sarcdata, entry.FileDataStart + sarc.DataOffset, data, 0, len);
+                        
+                        var path = Path.Combine(data_dir, sarc.GetFilePath(entry));
+                        var decompressed_path = Path.Combine(decompressed_data_dir, 
+                            Path.ChangeExtension(sarc.GetFilePath(entry),null));
 
                         CreateDirectoryIfNull(Path.GetDirectoryName(path));
                         CreateDirectoryIfNull(Path.GetDirectoryName(decompressed_path));
                         if (!File.Exists(path))
                         {
                             Log($"New {country} file: {Path.GetFileName(path)}");
-                            File.WriteAllBytes(path, data);
+                            File.WriteAllBytes(path, sarc.GetFileData(entry));
 
-                            if (BitConverter.ToUInt32(data, 0) == 0x307A6159) // 'Yaz0'
+                            var prbdata = sarc.GetDecompressedData(entry);
+                            File.WriteAllBytes(decompressed_path, prbdata);
+
+                            if (BitConverter.ToUInt32(prbdata, 0) == 0x53425250) // 'PRBS'
                             {
-                                var prbdata = SARC.Yaz0_Decompress(data);
-                                File.WriteAllBytes(decompressed_path, prbdata);
-                                //if (!Path.GetFileName(path).StartsWith("Pr_")) continue;
-                                if (BitConverter.ToUInt32(prbdata, 0) == 0x53425250) // 'PRBS'
+                                var prb = new PRBS(prbdata);
+                                var png_dir_full = Path.Combine("png",Path.Combine(Path.Combine("full", country), prb.CategoryName));
+                                var png_dir_tiles = Path.Combine("png", Path.Combine(Path.Combine("tiles", country), prb.CategoryName));
+                                var png_dir_downsampled = Path.Combine("png", Path.Combine(Path.Combine("downsampled", country), prb.CategoryName));
+                                CreateDirectoryIfNull(png_dir_full);
+                                CreateDirectoryIfNull(png_dir_tiles);
+                                CreateDirectoryIfNull(png_dir_downsampled);
+                                using (var bmp = prb.GetImage())
                                 {
-                                    var prb = new PRBS(prbdata);
-                                    var png_dir_full = Path.Combine("png",Path.Combine(Path.Combine("full", country), prb.CategoryName));
-                                    var png_dir_tiles = Path.Combine("png", Path.Combine(Path.Combine("tiles", country), prb.CategoryName));
-                                    var png_dir_downsampled = Path.Combine("png", Path.Combine(Path.Combine("downsampled", country), prb.CategoryName));
-                                    CreateDirectoryIfNull(png_dir_full);
-                                    CreateDirectoryIfNull(png_dir_tiles);
-                                    CreateDirectoryIfNull(png_dir_downsampled);
-                                    using (var bmp = prb.GetImage())
+                                    bmp.Save(Path.GetFullPath(Path.Combine(png_dir_full, prb.ImageName + ".png")),
+                                        ImageFormat.Png);
+
+                                    if (prb.NumTiles == 1)
                                     {
-                                        bmp.Save(Path.GetFullPath(Path.Combine(png_dir_full, prb.ImageName + ".png")),
+                                        bmp.Save(
+                                            Path.GetFullPath(Path.Combine(png_dir_tiles, prb.ImageName + ".png")),
                                             ImageFormat.Png);
-
-                                        if (prb.NumTiles == 1)
-                                        {
-                                            bmp.Save(
-                                                Path.GetFullPath(Path.Combine(png_dir_tiles, prb.ImageName + ".png")),
-                                                ImageFormat.Png);
-                                            bmp.Save(
-                                                Path.GetFullPath(Path.Combine(png_dir_downsampled, prb.ImageName + ".png")),
-                                                ImageFormat.Png);
-                                        }
+                                        bmp.Save(
+                                            Path.GetFullPath(Path.Combine(png_dir_downsampled, prb.ImageName + ".png")),
+                                            ImageFormat.Png);
                                     }
-                                    if (prb.NumTiles > 1)
-                                    {
-                                        using (var ptile = prb.GetTile(0))
-                                            ptile.Save(Path.GetFullPath(Path.Combine(png_dir_downsampled, prb.ImageName + ".downsampledpreview.png")), ImageFormat.Png);
-                                        for (var i = 0; i < prb.NumTiles; i++)
-                                        {
-                                            using (var tile = prb.GetTile(i+1))
-                                                tile.Save(Path.GetFullPath(Path.Combine(png_dir_tiles, prb.ImageName + $".tile_{i}.png")), ImageFormat.Png);
-                                        }
-                                    }
-
-                                    Log($"Saved {country} images for {prb.ImageName}.");
                                 }
+                                if (prb.NumTiles > 1)
+                                {
+                                    using (var ptile = prb.GetTile(0))
+                                        ptile.Save(Path.GetFullPath(Path.Combine(png_dir_downsampled, prb.ImageName + ".downsampledpreview.png")), ImageFormat.Png);
+                                    for (var i = 0; i < prb.NumTiles; i++)
+                                    {
+                                        using (var tile = prb.GetTile(i+1))
+                                            tile.Save(Path.GetFullPath(Path.Combine(png_dir_tiles, prb.ImageName + $".tile_{i}.png")), ImageFormat.Png);
+                                    }
+                                }
+
+                                Log($"Saved {country} images for {prb.ImageName}.");
                             }
                         }
                             

--- a/BadgeArcadeTool/SARC.cs
+++ b/BadgeArcadeTool/SARC.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
+using static System.String;
 
 namespace BadgeArcadeTool
 {
@@ -17,7 +16,7 @@ namespace BadgeArcadeTool
         public uint Unknown;
         public SFAT SFat;
         public SFNT SFnt;
-        public byte[] data;
+        public byte[] Data;
 
         public string FileName;
         public string FilePath;
@@ -47,55 +46,60 @@ namespace BadgeArcadeTool
                 sarc.FileSize = br.ReadUInt32();
                 sarc.DataOffset = br.ReadUInt32();
                 sarc.Unknown = br.ReadUInt32();
-                sarc.SFat = new SFAT();
-                sarc.SFat.Signature = new string(br.ReadChars(4));
+                sarc.SFat = new SFAT
+                {
+                    Signature = new string(br.ReadChars(4)),
+                    HeaderSize = br.ReadUInt16(),
+                    EntryCount = br.ReadUInt16(),
+                    HashMult = br.ReadUInt32(),
+                    Entries = new List<SFATEntry>()
+                };
                 if (sarc.SFat.Signature != "SFAT")
                 {
                     sarc.valid = false;
                     return sarc;
                 }
-                sarc.SFat.HeaderSize = br.ReadUInt16();
-                sarc.SFat.EntryCount = br.ReadUInt16();
-                sarc.SFat.HashMult = br.ReadUInt32();
-                sarc.SFat.Entries = new List<SFATEntry>();
-                for (int i = 0; i < sarc.SFat.EntryCount; i++)
+                for (var i = 0; i < sarc.SFat.EntryCount; i++)
                 {
-                    var s = new SFATEntry();
-                    s.FileNameHash = br.ReadUInt32();
-                    s.FileNameOffset = br.ReadUInt32();
-                    s.FileDataStart = br.ReadUInt32();
-                    s.FileDataEnd = br.ReadUInt32();
+                    var s = new SFATEntry
+                    {
+                        FileNameHash = br.ReadUInt32(),
+                        FileNameOffset = br.ReadUInt32(),
+                        FileDataStart = br.ReadUInt32(),
+                        FileDataEnd = br.ReadUInt32()
+                    };
                     sarc.SFat.Entries.Add(s);
                 }
-                sarc.SFnt = new SFNT();
-                sarc.SFnt.Signature = new string(br.ReadChars(4));
+                sarc.SFnt = new SFNT
+                {
+                    Signature = new string(br.ReadChars(4)),
+                    HeaderSize = br.ReadUInt16(),
+                    Unknown = br.ReadUInt16(),
+                    StringOffset = (uint)br.BaseStream.Position
+                };
                 if (sarc.SFnt.Signature != "SFNT")
                 {
                     sarc.valid = false;
                     return sarc;
                 }
-                sarc.SFnt.HeaderSize = br.ReadUInt16();
-                sarc.SFnt.Unknown = br.ReadUInt16();
-                sarc.SFnt.StringOffset = (uint)br.BaseStream.Position;
 
             }
-            sarc.data = File.ReadAllBytes(path);
-            if (sarc.FileSize != sarc.data.Length)
-            {
-                sarc.valid = false;
-                sarc.data = null;
-            }
+            sarc.Data = File.ReadAllBytes(path);
+            if (sarc.FileSize == sarc.Data.Length) return sarc;
+
+            sarc.valid = false;
+            sarc.Data = null;
             return sarc;
         }
 
         public string GetFilePath(SFATEntry entry)
         {
-            if (!valid) return String.Empty;
+            if (!valid) return Empty;
             var sb = new StringBuilder();
             var ofs = SFnt.StringOffset + (entry.FileNameOffset & 0xFFFFFF) * 4;
-            while (data[ofs] != 0)
+            while (Data[ofs] != 0)
             {
-                sb.Append((char)data[ofs++]);
+                sb.Append((char)Data[ofs++]);
             }
 
             return sb.ToString().Replace('/', Path.DirectorySeparatorChar);
@@ -105,9 +109,9 @@ namespace BadgeArcadeTool
         {
             if (!valid) return null;
             var len = entry.FileDataEnd - entry.FileDataStart;
-            var data = new byte[len];
-            Array.Copy(this.data, entry.FileDataStart + DataOffset, data, 0, len);
-            return data;
+            var d = new byte[len];
+            Array.Copy(Data, entry.FileDataStart + DataOffset, d, 0, len);
+            return d;
         }
 
         public byte[] GetDecompressedData(SFATEntry entry)
@@ -120,24 +124,24 @@ namespace BadgeArcadeTool
         }
 
 
-        public static byte[] Yaz0_Decompress(byte[] Data)
+        public static byte[] Yaz0_Decompress(byte[] data)
         {
-            var len = (uint)(Data[4] << 24 | Data[5] << 16 | Data[6] << 8 | Data[7]);
+            var len = (uint)(data[4] << 24 | data[5] << 16 | data[6] << 8 | data[7]);
             var result = new byte[len];
             var Offs = 16;
             var dstoffs = 0;
             while (true)
             {
-                var header = Data[Offs++];
+                var header = data[Offs++];
                 for (var i = 0; i < 8; i++)
                 {
-                    if ((header & 0x80) != 0) result[dstoffs++] = Data[Offs++];
+                    if ((header & 0x80) != 0) result[dstoffs++] = data[Offs++];
                     else
                     {
-                        var b = Data[Offs++];
-                        var offs = ((b & 0xF) << 8 | Data[Offs++]) + 1;
+                        var b = data[Offs++];
+                        var offs = ((b & 0xF) << 8 | data[Offs++]) + 1;
                         var length = (b >> 4) + 2;
-                        if (length == 2) length = Data[Offs++] + 0x12;
+                        if (length == 2) length = data[Offs++] + 0x12;
                         for (var j = 0; j < length; j++)
                         {
                             result[dstoffs] = result[dstoffs - offs];


### PR DESCRIPTION
Now takes far less time trying to connect to the crypto server when it is currently offline,  as in 3DS that is running it is shut down.

Fixed a minor thing where some times, the boss http server refuses to disclose the file size of the download.  (used the partial download code, to get the header, which contains the FULL file size within it.)

Fixed some possible exceptions regarding the code used to check for updates.

Code related to reading file names and file data from the SARC file moved into the SARC class.

Also, the decompressed data is saved for all of the files,  and the png files are now grouped, first by region, then by full size images, downscaled, and tiles, each in their own folder.